### PR TITLE
Modifications to GetAllRooms() as per HipChat docs for v2/rooms

### DIFF
--- a/src/Api/HipchatClient.cs
+++ b/src/Api/HipchatClient.cs
@@ -666,7 +666,7 @@ namespace HipchatApiV2
         /// <remarks>
         /// Auth required with scope 'view_group'. https://www.hipchat.com/docs/apiv2/method/get_all_rooms
         /// </remarks>
-        public HipchatGetAllRoomsResponse GetAllRooms(int startIndex = 0, int maxResults = 100, bool includeArchived = false)
+        public HipchatGetAllRoomsResponse GetAllRooms(int startIndex = 0, int maxResults = 100, bool includePrivate = false, bool includeArchived = false)
         {
             using (JsonSerializerConfigScope())
             {
@@ -680,6 +680,7 @@ namespace HipchatApiV2
                     return HipchatEndpoints.GetAllRoomsEndpoint
                         .AddQueryParam("start-index", startIndex)
                         .AddQueryParam("max-results", maxResults)
+                        .AddQueryParam("include-private", includePrivate)
                         .AddQueryParam("include-archived", includeArchived)
                         .AddHipchatAuthentication(_authToken)
                         .GetJsonFromUrl()


### PR DESCRIPTION
- maxResults increased from 100 to 1,000 per page.  
- Support for "include-private" parameter added.

Both added to reflect current documentation (at time of commit) at https://www.hipchat.com/docs/apiv2/method/get_all_rooms.
