### PR TITLE
Added self-hosted hip-chat servers

### DIFF
--- a/src/Api/HipchatClient.cs
+++ b/src/Api/HipchatClient.cs
@@ -23,9 +23,12 @@ namespace HipchatApiV2
         /// file appSettings for 'hipchat_auth_token'
         /// </summary>
         /// <param name="authToken">the auth token given by hipchat</param>
-        public HipchatClient(string authToken = null)
+        /// <param name="serverName">self hosted server name</param>
+        public HipchatClient(string authToken = null, string serverName = null)
         {
             _authToken = authToken ?? HipchatApiConfig.AuthToken;
+
+            HipchatEndpoints.SetEndpointHost(serverName);
 
             ConfigureSerializer();
         }

--- a/src/Api/HipchatClient.cs
+++ b/src/Api/HipchatClient.cs
@@ -23,7 +23,7 @@ namespace HipchatApiV2
         /// file appSettings for 'hipchat_auth_token'
         /// </summary>
         /// <param name="authToken">the auth token given by hipchat</param>
-        /// <param name="serverName">self hosted server name</param>
+        /// <param name="serverName">self hosted server name, use null for hipchat.com</param>
         public HipchatClient(string authToken = null, string serverName = null)
         {
             _authToken = authToken ?? HipchatApiConfig.AuthToken;

--- a/src/Api/HipchatEndpoints.cs
+++ b/src/Api/HipchatEndpoints.cs
@@ -7,14 +7,17 @@ namespace HipchatApiV2
     public class HipchatEndpoints
     {
         private static string EndpointHost;
+
+        private const string HipChatApi = "api.hipchat.com";
+
         static HipchatEndpoints()
         {
-            EndpointHost = ConfigurationManager.AppSettings["hipchat_endpoint_host"] ?? "api.hipchat.com";
+            EndpointHost = ConfigurationManager.AppSettings["hipchat_endpoint_host"] ?? HipChatApi;
         }
 
         public static void SetEndpointHost(string host)
         {
-            EndpointHost = host;
+            EndpointHost = host ?? HipChatApi;
         }
 
         private HipchatEndpoints() {}

--- a/src/Api/HipchatEndpoints.cs
+++ b/src/Api/HipchatEndpoints.cs
@@ -6,10 +6,15 @@ namespace HipchatApiV2
 {
     public class HipchatEndpoints
     {
-        private static readonly string EndpointHost;
+        private static string EndpointHost;
         static HipchatEndpoints()
         {
             EndpointHost = ConfigurationManager.AppSettings["hipchat_endpoint_host"] ?? "api.hipchat.com";
+        }
+
+        public static void SetEndpointHost(string host)
+        {
+            EndpointHost = host;
         }
 
         private HipchatEndpoints() {}
@@ -36,7 +41,6 @@ namespace HipchatApiV2
         public static string UpdateUserEndpointFormat { get { return String.Format("https://{0}/v2/user/{{0}}", EndpointHost); } }
         public static string DeleteUserEndpointFormat { get { return String.Format("https://{0}/v2/user/{{0}}", EndpointHost); } }
         public static string PrivateMessageUserEnpointFormat {get { return string.Format("https://{0}/v2/user/{{0}}/message", EndpointHost); }}
-
         public static string AddMemberEnpdointFormat { get { return String.Format("https://{0}/v2/room/{{0}}/member/{{1}}", EndpointHost); } }
         public static string UpdatePhotoEnpdointFormat { get { return String.Format("https://{0}/v2/user/{{0}}/photo", EndpointHost); } }
     }


### PR DESCRIPTION
Added the ability to connect to your own server, without the use of application settings.

Example:
`var client = new HipchatClient(this.AuthToken, this.ServerName);`
`client.SendNotification(RoomName, message);`
            